### PR TITLE
feat: support passing in a schema

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -30,6 +30,7 @@ The chart currently use external postgres servers.
 | database.password | string | `"supersecretpassword"` | database user password |
 | database.port | int | `5432` | database port |
 | database.user | string | `"supertokens"` | database username |
+| database.schema | string | `"supertokens"` | database schema |
 | database.connectionPoolSize | int | `5` | maximum postgres connection pool size |
 | accessTokenValidity | int | `3600` | Time in seconds for how long an access token is valid for |
 | accessTokenBlacklisting | bool | `false` | If true, allows for immediate revocation of any access token. Keep in mind that setting this to true will result in a db query for each API call that requires authentication. |

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: {{ quote .Values.database.user }}
             - name: "POSTGRESQL_PASSWORD"
               value: {{ quote .Values.database.password }}
+            - name: "POSTGRESQL_TABLE_SCHEMA"
+              value: {{ quote .Values.database.schema }}
             - name: "POSTGRESQL_CONNECTION_POOL_SIZE"
               value: {{ quote .Values.database.connectionPoolSize }}
             - name: "SUPERTOKENS_PORT"


### PR DESCRIPTION
According to the docs (https://supertokens.com/docs/thirdpartyemailpassword/quick-setup/database-setup/postgresql) POSTGRESQL_TABLE_SCHEMA is a valid envvar for the docker container.  This small PR adds this value as a parameter to the helm chart.