### PR TITLE
Use targetPort for SUPERTOKENS_PORT

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               value: {{ quote .Values.database.connectionPoolSize }}
             {{- end }}
             - name: "SUPERTOKENS_PORT"
-              value: {{ quote .Values.service.port }}
+              value: {{ quote .Values.service.targetPort }}
             - name: "ACCESS_TOKEN_VALIDITY"
               value: {{ quote .Values.accessTokenValidity }}
             - name: "ACCESS_TOKEN_BLACKLISTING"


### PR DESCRIPTION
Deployment in the helm chart uses service.port as the value for SUPERTOKENS_PORT variable, whereas `port` should be used for the port you want to expose for the deployment and `targetPort` should be used as the port for the internal service.

I was having issues when deploying this helm as I needed to host it over a loadbalancer and I wanted to use port 80 for ingress but when I would do that in the chart the deployment would fail.