### PR TITLE
changed the core version to include x.x.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,7 @@ jobs:
             docker buildx inspect --bootstrap
             CORE_VERSION_WITH_PATCH=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
             CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2 | cut -d'.' -f1,2)
-            if [ "$CORE_VERSION" != "$CORE_VERSION_WITH_PATCH" ]; then
-              docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -t supertokens/supertokens-postgresql:${CORE_VERSION_WITH_PATCH} -o type=image,push=true .
-            else
-              docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -o type=image,push=true .
-            fi
+            docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -t supertokens/supertokens-postgresql:${CORE_VERSION_WITH_PATCH} -o type=image,push=true .
       - run:
           name: check if is latest core and plugin
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: core version tag
           command: |
-            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
+            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2 | cut -d'.' -f1,2)
             git push origin :refs/tags/${CORE_VERSION}
             git fetch --prune --prune-tags
             git tag ${CORE_VERSION}
@@ -37,8 +37,13 @@ jobs:
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx create --name multiarch --driver docker-container --use
             docker buildx inspect --bootstrap
-            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
-            docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -o type=image,push=true .
+            CORE_VERSION_WITH_PATCH=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
+            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2 | cut -d'.' -f1,2)
+            if [ "$CORE_VERSION" != "$CORE_VERSION_WITH_PATCH" ]; then
+              docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -t supertokens/supertokens-postgresql:${CORE_VERSION_WITH_PATCH} -o type=image,push=true .
+            else
+              docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -o type=image,push=true .
+            fi
       - run:
           name: check if is latest core and plugin
           command: |
@@ -86,7 +91,7 @@ workflows:
             - docker-hub
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/   
+              only: /v[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: core version tag
           command: |
-            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2 | cut -d'.' -f1,2)
+            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
             git push origin :refs/tags/${CORE_VERSION}
             git fetch --prune --prune-tags
             git tag ${CORE_VERSION}
@@ -37,7 +37,7 @@ jobs:
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx create --name multiarch --driver docker-container --use
             docker buildx inspect --bootstrap
-            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2 | cut -d'.' -f1,2)
+            CORE_VERSION=$(cat Dockerfile | grep "ARG CORE_VERSION=" | cut -d'=' -f2)
             docker buildx build --platform $BUILDX_PLATFORMS -t supertokens/supertokens-postgresql:${CORE_VERSION} -o type=image,push=true .
       - run:
           name: check if is latest core and plugin
@@ -86,7 +86,7 @@ workflows:
             - docker-hub
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*/   
             branches:
               ignore: /.*/
       - test:


### PR DESCRIPTION
Made changes for tagging the docker image for supertoken core postgres to enable pushing of x.x.x along with x.x . 

Tests performed:
Added multi tagging and fetching the version from docker file. Fetching works fine, tried in local shell and for the tags checked for a dummy container using same syntax, working fine. For multi tags:
Ran following command locally and tested both tags are present on dockerhub. 
`docker buildx build -t piyush0810/temp:1 -t piyush0810/temp:2 -o type=image,push=true .`