### PR TITLE
fix: docker readonly fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN echo "$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')" >> /CONFIG_HASH
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 EXPOSE 3567
+USER "supertokens"
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["supertokens", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20200219 as tmp
 ARG PLUGIN_NAME=postgresql
 ARG PLAN_TYPE=FREE
-ARG CORE_VERSION=9.2.2
+ARG CORE_VERSION=9.2.3
 ARG PLUGIN_VERSION=7.1.3
 RUN apt-get update && apt-get install -y curl zip
 RUN OS= && dpkgArch="$(dpkg --print-architecture)" && \

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ docker run \
 
 
 ## Read-only root fs
-- If you wish to run this container with a read-only root filesystem, you should use the `--read-only` flag *for the container too*.
+- If you wish to run this container with a read-only root filesystem, you can do so.
 - The container still needs a temp area, where it can write its stuff, and also needs to be able to execute from there.
 - You will have to create a mount for `/lib/supertokens/temp/`
 
@@ -125,7 +125,7 @@ docker run \
 	-p 3567:3567 \
 	--mount source=/path/on/host/machine,destination=/lib/supertokens/temp/,type=bind \
 	--read-only \
-	-d registry.supertokens.io/supertokens/supertokens-postgresql --read-only
+	-d registry.supertokens.io/supertokens/supertokens-postgresql
 ```
 
 ```bash
@@ -133,5 +133,5 @@ docker run \
 	-p 3567:3567 \
 	--tmpfs=/lib/supertokens/temp/:exec \
 	--read-only \
-	-d registry.supertokens.io/supertokens/supertokens-postgresql --read-only
+	-d registry.supertokens.io/supertokens/supertokens-postgresql
 ```

--- a/README.md
+++ b/README.md
@@ -113,3 +113,25 @@ docker run \
 - Before you start this container, make sure to initialize your database.
 - You do not need to ensure that the Postgresql database has started before this container is started. During bootup, SuperTokens will wait for ~1 hour for a Postgresql instance to be available.
 - If `POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `POSTGRESQL_PASSWORD_FILE` and `POSTGRESQL_CONNECTION_URI` are not provided, then SuperTokens will use an in memory database.
+
+
+## Read-only root fs
+- If you wish to run this container with a read-only root filesystem, you should use the `--read-only` flag *for the container too*.
+- The container still needs a temp area, where it can write its stuff, and also needs to be able to execute from there.
+- You will have to create a mount for `/lib/supertokens/temp/`
+
+```bash
+docker run \
+	-p 3567:3567 \
+	--mount source=/path/on/host/machine,destination=/lib/supertokens/temp/,type=bind \
+	--read-only \
+	-d registry.supertokens.io/supertokens/supertokens-postgresql --read-only
+```
+
+```bash
+docker run \
+	-p 3567:3567 \
+	--tmpfs=/lib/supertokens/temp/:exec \
+	--read-only \
+	-d registry.supertokens.io/supertokens/supertokens-postgresql --read-only
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,22 +33,19 @@ fi
 
 CONFIG_FILE=/usr/lib/supertokens/config.yaml
 TEMP_LOCATION_WHEN_READONLY=/lib/supertokens/temp/
+mkdir -p $TEMP_LOCATION_WHEN_READONLY
 CONFIG_MD5SUM="$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')"
 
-#if it contains the readonly param, make that temp dir a temp dir for java io too
-if [[ "$*" == *--read-only* ]]
-then
-  #required by JNA
-  export _JAVA_OPTIONS=-Djava.io.tmpdir=$TEMP_LOCATION_WHEN_READONLY
+# always assuming read-only
 
-  #changing where the config file is written
-  ORIGINAL_CONFIG=$CONFIG_FILE
-  CONFIG_FILE="${TEMP_LOCATION_WHEN_READONLY}/config.yaml"
-  cat $ORIGINAL_CONFIG >> $CONFIG_FILE
-
-  #make sure the CLI knows which config file to pass to the core
-  set -- "$@" --with-config="$CONFIG_FILE" --with-temp-dir="$TEMP_LOCATION_WHEN_READONLY" --foreground
-fi
+#changing where the config file is written
+ORIGINAL_CONFIG=$CONFIG_FILE
+CONFIG_FILE="${TEMP_LOCATION_WHEN_READONLY}config.yaml"
+cat $ORIGINAL_CONFIG >> $CONFIG_FILE
+#required by JNA
+export _JAVA_OPTIONS=-Djava.io.tmpdir=$TEMP_LOCATION_WHEN_READONLY
+#make sure the CLI knows which config file to pass to the core
+set -- "$@" --with-config="$CONFIG_FILE" --with-temp-dir="$TEMP_LOCATION_WHEN_READONLY" --foreground
 
 
 if [ "$CONFIG_HASH" = "$CONFIG_MD5SUM" ]

--- a/test.sh
+++ b/test.sh
@@ -81,107 +81,107 @@ NETWORK_OPTIONS="-p 3567:3567 -e POSTGRESQL_HOST=$POSTGRES_IP"
 NETWORK_OPTIONS_CONNECTION_URI="-p 3567:3567 -e POSTGRESQL_CONNECTION_URI=postgresql://root:root@$POSTGRES_IP:5432"
 printf "\npostgresql_host: \"$POSTGRES_IP\"" >> $PWD/config.yaml
 
-##---------------------------------------------------
-## start with no options
-#docker run -e DISABLE_TELEMETRY=true --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 10s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with no options"
-#
-##---------------------------------------------------
-## start with no network options, but in mem db
-#docker run -e DISABLE_TELEMETRY=true -p 3567:3567 --rm -d --name supertokens supertokens-postgresql:circleci
-#
-#sleep 17s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with no network options, but in mem db"
-#
-#test_hello "start with no network options, but in mem db"
-#
-#test_session_post "start with no network options, but in mem db"
-#
-#docker rm supertokens -f
-#
-##---------------------------------------------------
-## start with postgresql password
-#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 10s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql password"
-#
-##---------------------------------------------------
-## start with postgresql user
-#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 10s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql user"
-#
-##---------------------------------------------------
-## start with postgresql user, postgresql password
-#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 17s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql user, postgresql password"
-#
-#test_hello "start with postgresql user, postgresql password"
-#
-#test_session_post "start with postgresql user, postgresql password"
-#
-#docker rm supertokens -f
-#
-##---------------------------------------------------
-## start with postgresql connection uri
-#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 17s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql connection uri"
-#
-#test_hello "starstart with postgresql connection uri"
-#
-#test_session_post "start with postgresql connection uri"
-#
-#docker rm supertokens -f
-#
-##---------------------------------------------------
-## start by sharing config.yaml
-#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD/config.yaml:/usr/lib/supertokens/config.yaml --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 17s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start by sharing config.yaml"
-#
-#test_hello "start by sharing config.yaml"
-#
-#test_session_post "start by sharing config.yaml"
-#
-#docker rm supertokens -f
-#
-## ---------------------------------------------------
-## test info path
-#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD:/home/supertokens -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root -e INFO_LOG_PATH=/home/supertokens/info.log -e ERROR_LOG_PATH=/home/supertokens/error.log --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-#
-#sleep 17s
-#
-#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test info path"
-#
-#test_hello "test info path"
-#
-#test_session_post "test info path"
-#
-#if [[ ! -f $PWD/info.log || ! -f $PWD/error.log ]]
-#then
-#    exit 1
-#fi
-#
-#docker rm supertokens -f
-#
-#rm -rf $PWD/info.log
-#rm -rf $PWD/error.log
+#---------------------------------------------------
+# start with no options
+docker run -e DISABLE_TELEMETRY=true --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 10s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with no options"
+
+#---------------------------------------------------
+# start with no network options, but in mem db
+docker run -e DISABLE_TELEMETRY=true -p 3567:3567 --rm -d --name supertokens supertokens-postgresql:circleci
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with no network options, but in mem db"
+
+test_hello "start with no network options, but in mem db"
+
+test_session_post "start with no network options, but in mem db"
+
+docker rm supertokens -f
+
+#---------------------------------------------------
+# start with postgresql password
+docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 10s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql password"
+
+#---------------------------------------------------
+# start with postgresql user
+docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 10s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql user"
+
+#---------------------------------------------------
+# start with postgresql user, postgresql password
+docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql user, postgresql password"
+
+test_hello "start with postgresql user, postgresql password"
+
+test_session_post "start with postgresql user, postgresql password"
+
+docker rm supertokens -f
+
+#---------------------------------------------------
+# start with postgresql connection uri
+docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql connection uri"
+
+test_hello "starstart with postgresql connection uri"
+
+test_session_post "start with postgresql connection uri"
+
+docker rm supertokens -f
+
+#---------------------------------------------------
+# start by sharing config.yaml
+docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD/config.yaml:/usr/lib/supertokens/config.yaml --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start by sharing config.yaml"
+
+test_hello "start by sharing config.yaml"
+
+test_session_post "start by sharing config.yaml"
+
+docker rm supertokens -f
+
+# ---------------------------------------------------
+# test info path
+docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD:/home/supertokens -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root -e INFO_LOG_PATH=/home/supertokens/info.log -e ERROR_LOG_PATH=/home/supertokens/error.log --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test info path"
+
+test_hello "test info path"
+
+test_session_post "test info path"
+
+if [[ ! -f $PWD/info.log || ! -f $PWD/error.log ]]
+then
+    exit 1
+fi
+
+docker rm supertokens -f
+
+rm -rf $PWD/info.log
+rm -rf $PWD/error.log
 git checkout $PWD/config.yaml
 
 #---------------------------------------------------

--- a/test.sh
+++ b/test.sh
@@ -226,7 +226,7 @@ docker rm supertokens -f
 
 #---------------------------------------------------
 # test --read-only ARGON2
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
 
 sleep 17s
 

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,32 @@ test_session_post () {
     fi
 }
 
+test_signup_post () {
+    message=$1
+    STATUS_CODE=$(curl -X POST http://127.0.0.1:3567/recipe/signup -H "Content-Type: application/json" -d '{
+        "email": "testing@testing.test",
+        "password": "testpassword"
+    }' -o /dev/null -w '%{http_code}\n' -s)
+    if [[ $STATUS_CODE -ne "200" ]]
+    then
+        printf "\x1b[1;31merror\xd1b[0m from test_signup_post in $message\n"
+        exit 1
+    fi
+}
+
+test_signin_post () {
+    message=$1
+    STATUS_CODE=$(curl -X POST http://127.0.0.1:3567/recipe/signin -H "Content-Type: application/json" -d '{
+        "email": "testing@testing.test",
+        "password": "testpassword"
+    }' -o /dev/null -w '%{http_code}\n' -s)
+    if [[ $STATUS_CODE -ne "200" ]]
+    then
+        printf "\x1b[1;31merror\xd1b[0m from test_signup_post in $message\n"
+        exit 1
+    fi
+}
+
 no_of_containers_running_at_start=`no_of_running_containers`
 
 # start postgresql server
@@ -55,108 +81,144 @@ NETWORK_OPTIONS="-p 3567:3567 -e POSTGRESQL_HOST=$POSTGRES_IP"
 NETWORK_OPTIONS_CONNECTION_URI="-p 3567:3567 -e POSTGRESQL_CONNECTION_URI=postgresql://root:root@$POSTGRES_IP:5432"
 printf "\npostgresql_host: \"$POSTGRES_IP\"" >> $PWD/config.yaml
 
-#---------------------------------------------------
-# start with no options
-docker run -e DISABLE_TELEMETRY=true --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db 
-
-sleep 10s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with no options"
-
-#---------------------------------------------------
-# start with no network options, but in mem db
-docker run -e DISABLE_TELEMETRY=true -p 3567:3567 --rm -d --name supertokens supertokens-postgresql:circleci
-
-sleep 17s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with no network options, but in mem db"
-
-test_hello "start with no network options, but in mem db"
-
-test_session_post "start with no network options, but in mem db"
-
-docker rm supertokens -f
-
-#---------------------------------------------------
-# start with postgresql password
-docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-
-sleep 10s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql password"
-
-#---------------------------------------------------
-# start with postgresql user
-docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-
-sleep 10s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql user"
-
-#---------------------------------------------------
-# start with postgresql user, postgresql password
-docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-
-sleep 17s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql user, postgresql password"
-
-test_hello "start with postgresql user, postgresql password"
-
-test_session_post "start with postgresql user, postgresql password"
-
-docker rm supertokens -f
-
-#---------------------------------------------------
-# start with postgresql connection uri
-docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-
-sleep 17s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql connection uri"
-
-test_hello "starstart with postgresql connection uri"
-
-test_session_post "start with postgresql connection uri"
-
-docker rm supertokens -f
-
-#---------------------------------------------------
-# start by sharing config.yaml
-docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD/config.yaml:/usr/lib/supertokens/config.yaml --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-
-sleep 17s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start by sharing config.yaml"
-
-test_hello "start by sharing config.yaml"
-
-test_session_post "start by sharing config.yaml"
-
-docker rm supertokens -f
-
-# ---------------------------------------------------
-# test info path
-docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD:/home/supertokens -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root -e INFO_LOG_PATH=/home/supertokens/info.log -e ERROR_LOG_PATH=/home/supertokens/error.log --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
-
-sleep 17s
-
-test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test info path"
-
-test_hello "test info path"
-
-test_session_post "test info path"
-
-if [[ ! -f $PWD/info.log || ! -f $PWD/error.log ]]
-then
-    exit 1
-fi
-
-docker rm supertokens -f
-
-rm -rf $PWD/info.log
-rm -rf $PWD/error.log
+##---------------------------------------------------
+## start with no options
+#docker run -e DISABLE_TELEMETRY=true --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 10s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with no options"
+#
+##---------------------------------------------------
+## start with no network options, but in mem db
+#docker run -e DISABLE_TELEMETRY=true -p 3567:3567 --rm -d --name supertokens supertokens-postgresql:circleci
+#
+#sleep 17s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with no network options, but in mem db"
+#
+#test_hello "start with no network options, but in mem db"
+#
+#test_session_post "start with no network options, but in mem db"
+#
+#docker rm supertokens -f
+#
+##---------------------------------------------------
+## start with postgresql password
+#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 10s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql password"
+#
+##---------------------------------------------------
+## start with postgresql user
+#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 10s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+1)) "start with postgresql user"
+#
+##---------------------------------------------------
+## start with postgresql user, postgresql password
+#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 17s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql user, postgresql password"
+#
+#test_hello "start with postgresql user, postgresql password"
+#
+#test_session_post "start with postgresql user, postgresql password"
+#
+#docker rm supertokens -f
+#
+##---------------------------------------------------
+## start with postgresql connection uri
+#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 17s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start with postgresql connection uri"
+#
+#test_hello "starstart with postgresql connection uri"
+#
+#test_session_post "start with postgresql connection uri"
+#
+#docker rm supertokens -f
+#
+##---------------------------------------------------
+## start by sharing config.yaml
+#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD/config.yaml:/usr/lib/supertokens/config.yaml --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 17s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "start by sharing config.yaml"
+#
+#test_hello "start by sharing config.yaml"
+#
+#test_session_post "start by sharing config.yaml"
+#
+#docker rm supertokens -f
+#
+## ---------------------------------------------------
+## test info path
+#docker run -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -v $PWD:/home/supertokens -e POSTGRESQL_USER=root -e POSTGRESQL_PASSWORD=root -e INFO_LOG_PATH=/home/supertokens/info.log -e ERROR_LOG_PATH=/home/supertokens/error.log --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db
+#
+#sleep 17s
+#
+#test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test info path"
+#
+#test_hello "test info path"
+#
+#test_session_post "test info path"
+#
+#if [[ ! -f $PWD/info.log || ! -f $PWD/error.log ]]
+#then
+#    exit 1
+#fi
+#
+#docker rm supertokens -f
+#
+#rm -rf $PWD/info.log
+#rm -rf $PWD/error.log
 git checkout $PWD/config.yaml
+
+#---------------------------------------------------
+# test --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test --read-only"
+
+test_hello "test --read-only"
+
+test_session_post "test --read-only"
+
+test_signup_post "test --read-only"
+
+test_signin_post "test --read-only"
+
+docker rm supertokens -f
+
+#---------------------------------------------------
+# test --read-only ARGON2
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-postgresql:circleci --no-in-mem-db --read-only
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test --read-only ARGON2"
+
+test_hello "test --read-only ARGON2"
+
+test_session_post "test --read-only ARGON2"
+
+test_signup_post "test --read-only ARGON2"
+
+test_signin_post "test --read-only ARGON2"
+
+docker rm supertokens -f
 
 docker rm postgres -f
 

--- a/test.sh
+++ b/test.sh
@@ -60,7 +60,7 @@ test_signin_post () {
     }' -o /dev/null -w '%{http_code}\n' -s)
     if [[ $STATUS_CODE -ne "200" ]]
     then
-        printf "\x1b[1;31merror\xd1b[0m from test_signup_post in $message\n"
+        printf "\x1b[1;31merror\xd1b[0m from test_signin_post in $message\n"
         exit 1
     fi
 }


### PR DESCRIPTION
- Adds support for readonly root filesystem. (`--read-only`), but for that requires at least a `--tmpfs` for `/lib/supertokens/temp`
- Changes the user in the container from `root` to `supertokens`
- Removes operations from entrypoint which would require root user.